### PR TITLE
Fix compiler warning when CRYPTO_ALG_KERN_DRIVER_ONLY is defined, and Add check for "atmel-" HW accelerator.

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -710,9 +710,10 @@ static inline void tfm_info_to_alg_info(struct alg_info *dst, struct crypto_tfm 
 			"%s", crypto_tfm_alg_driver_name(tfm));
 }
 
+#ifndef CRYPTO_ALG_KERN_DRIVER_ONLY
 static unsigned int is_known_accelerated(struct crypto_tfm *tfm)
 {
-const char* name = crypto_tfm_alg_driver_name(tfm);
+	const char* name = crypto_tfm_alg_driver_name(tfm);
 
 	if (name == NULL)
 	  return 1; /* assume accelerated */
@@ -721,6 +722,8 @@ const char* name = crypto_tfm_alg_driver_name(tfm);
 	  return 1;
 	else if (strncmp(name, "mv-", 3) == 0)
 	  return 1;
+	else if (strncmp(name, "atmel-", 6) == 0)
+		return 1;
 	else if (strstr(name, "geode"))
 	  return 1;
 	else if (strstr(name, "hifn"))
@@ -742,6 +745,7 @@ const char* name = crypto_tfm_alg_driver_name(tfm);
 
 	return 0;
 }
+#endif
 
 static int get_session_info(struct fcrypt *fcr, struct session_info_op *siop)
 {


### PR DESCRIPTION
ioctl.c:714:21: warning: 'is_known_accelerated' defined but not used [-Wunused-function]

Add check for "atmel-" HW accelerator.

Signed-off-by: Karl Hiramoto karl@hiramoto.org
