### PR TITLE
fix benchmarks linking

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -3,7 +3,7 @@ CFLAGS=-g -O2 -Wall
 all: benchmark
 
 benchmark: main.c libthreshold.a
-	gcc $(CFLAGS) -DDEBUG -o $@ $^ -lssl libthreshold.a
+	gcc $(CFLAGS) -DDEBUG -o $@ $^ -lssl -lcrypto libthreshold.a
 
 .o:
 	gcc $(CCFLAGS) -c $< -o $@


### PR DESCRIPTION
Fixes:
```
:~$ make 
cc -g -O2 -Wall   -c -o benchmark.o benchmark.c
cc -g -O2 -Wall   -c -o hash.o hash.c
cc -g -O2 -Wall   -c -o threshold.o threshold.c
cc -g -O2 -Wall   -c -o combo.o combo.c
ar  rcs libthreshold.a benchmark.o hash.o threshold.o combo.o
gcc -g -O2 -Wall -DDEBUG -o benchmark main.c libthreshold.a -lssl libthreshold.a
/usr/bin/ld: libthreshold.a(threshold.o): undefined reference to symbol 'AES_set_encrypt_key@@libcrypto.so.10'
/lib64/libcrypto.so.10: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:6: recipe for target 'benchmark' failed
make: *** [benchmark] Error 1
```
