### PR TITLE
Adjust to recent user page API changes

### DIFF
--- a/zc.c
+++ b/zc.c
@@ -59,7 +59,12 @@ int __get_userbuf(uint8_t __user *addr, uint32_t len, int write,
 	}
 
 	down_read(&mm->mmap_sem);
-	ret = get_user_pages(task, mm,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0))
+	ret = get_user_pages_remote(
+#else
+	ret = get_user_pages(
+#endif
+			task, mm,
 			(unsigned long)addr, pgcount, write, 0, pg, NULL);
 	up_read(&mm->mmap_sem);
 	if (ret != pgcount)
@@ -119,7 +124,7 @@ void release_user_pages(struct csession *ses)
 		else
 			ses->readonly_pages--;
 
-		page_cache_release(ses->pages[i]);
+		put_page(ses->pages[i]);
 	}
 	ses->used_pages = 0;
 }


### PR DESCRIPTION
4.6.0 basically renamed get_user_pages() to get_user_pages_remote() and
introduced a new get_user_pages() that always works on the current
task.[1] Distinguish the two APIs based on kernel version we're
compiling for.

Also, there seems to have been a massive cleansing of
page_cache_release(page) in favour of put_page(page)[2] which was an
alias for put_page(page)[3] at least as far back as 3.10[4]. So just
switch to that.

[1] https://lkml.org/lkml/2016/2/10/555
[2] https://www.spinics.net/lists/linux-fsdevel/msg95923.html
[3] https://www.spinics.net/lists/linux-fsdevel/msg95922.html
[4] http://lxr.free-electrons.com/source/include/linux/pagemap.h?v=3.10#L101