### PR TITLE
Fix test compile time warnings

### DIFF
--- a/tests/hashcrypt_speed.c
+++ b/tests/hashcrypt_speed.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/tests/sha_speed.c
+++ b/tests/sha_speed.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/tests/speed.c
+++ b/tests/speed.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <sys/types.h>


### PR DESCRIPTION
A number of tests cause compiler warnings like this:

hashcrypt_speed.c: In function ‘hash_data’:
hashcrypt_speed.c:101:2: warning: implicit declaration of function ‘alarm’ [-Wimplicit-function-declaration]
  alarm(5);
  ^~~~~
hashcrypt_speed.c: In function ‘main’:
hashcrypt_speed.c:203:2: warning: implicit declaration of function ‘close’ [-Wimplicit-function-declaration]
  close(fdc);
  ^~~~~

Fix by including unistd.h.