### PR TITLE
Adjust to another change in the user page API

### DIFF
--- a/zc.c
+++ b/zc.c
@@ -65,7 +65,13 @@ int __get_userbuf(uint8_t __user *addr, uint32_t len, int write,
 	ret = get_user_pages(
 #endif
 			task, mm,
-			(unsigned long)addr, pgcount, write, 0, pg, NULL);
+			(unsigned long)addr, pgcount,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0))
+			write ? FOLL_WRITE : 0,
+#else
+			write, 0,
+#endif
+			pg, NULL);
 	up_read(&mm->mmap_sem);
 	if (ret != pgcount)
 		return -EINVAL;


### PR DESCRIPTION
4.9.0 will replace the write and force flags of get_user_pages_remote()
with a gup_flags parameter[1]. Distinguish the two APIs based on kernel
version we're compiling for.

[1] https://github.com/torvalds/linux/commit/9beae1ea89305a9667ceaab6d0bf46a045ad71e7