### PR TITLE
Added support for compression algorithms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,14 @@ install: modules_install
 
 modules_install:
 	$(MAKE) $(KERNEL_MAKE_OPTS) modules_install
+	insmod /lib/modules/4.11.0-13-generic/extra/cryptodev.ko
 	install -m 644 -D crypto/cryptodev.h $(DESTDIR)/$(includedir)/crypto/cryptodev.h
 
 clean:
 	$(MAKE) $(KERNEL_MAKE_OPTS) clean
 	rm -f $(hostprogs) *~
 	CFLAGS=$(CRYPTODEV_CFLAGS) KERNEL_DIR=$(KERNEL_DIR) $(MAKE) -C tests clean
+	rmmod cryptodev
 
 check:
 	CFLAGS=$(CRYPTODEV_CFLAGS) KERNEL_DIR=$(KERNEL_DIR) $(MAKE) -C tests check

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ install: modules_install
 
 modules_install:
 	$(MAKE) $(KERNEL_MAKE_OPTS) modules_install
-	insmod /lib/modules/4.11.0-13-generic/extra/cryptodev.ko
+	insmod /lib/modules/$(shell uname -r)/extra/cryptodev.ko
 	install -m 644 -D crypto/cryptodev.h $(DESTDIR)/$(includedir)/crypto/cryptodev.h
 
 clean:

--- a/cryptlib.c
+++ b/cryptlib.c
@@ -483,13 +483,13 @@ void cryptodev_compr_deinit(struct compr_data *cdata)
 
 ssize_t cryptodev_compr_compress(struct compr_data *cdata,
 		const struct scatterlist *src, struct scatterlist *dst,
-		size_t len)
+		size_t slen, size_t dlen)
 {
 	int ret;
 
 	reinit_completion(&cdata->async.result.completion);
 
-	acomp_request_set_params(cdata->async.request, (struct scatterlist *)src, dst, len, len);
+	acomp_request_set_params(cdata->async.request, (struct scatterlist *)src, dst, slen, dlen);
 	ret = crypto_acomp_compress(cdata->async.request);
 
 	return waitfor(&cdata->async.result, ret);
@@ -497,13 +497,13 @@ ssize_t cryptodev_compr_compress(struct compr_data *cdata,
 
 ssize_t cryptodev_compr_decompress(struct compr_data *cdata,
 		const struct scatterlist *src, struct scatterlist *dst,
-		size_t len)
+		size_t slen, size_t dlen)
 {
 	int ret;
 
 	reinit_completion(&cdata->async.result.completion);
 
-	acomp_request_set_params(cdata->async.request, (struct scatterlist *)src, dst, len, len);
+	acomp_request_set_params(cdata->async.request, (struct scatterlist *)src, dst, slen, dlen);
 	ret = crypto_acomp_decompress(cdata->async.request);
 
 	return waitfor(&cdata->async.result, ret);

--- a/cryptlib.c
+++ b/cryptlib.c
@@ -439,7 +439,6 @@ int cryptodev_hash_final(struct hash_data *hdata, void *output)
 int cryptodev_compr_init(struct compr_data *cdata, const char *alg_name)
 {
 	int ret;
-	struct crypto_tfm *tfm;
 	
 	cdata->async.s = crypto_alloc_acomp(alg_name, 0, 0);
 	if (unlikely(IS_ERR(cdata->async.s))) {
@@ -447,7 +446,7 @@ int cryptodev_compr_init(struct compr_data *cdata, const char *alg_name)
 			return -EINVAL;
 	}
 	
-	cdata->alignmask = crypto_tfm_alg_alignmask(crypto_acomp_tfm(out->async.s)); 
+	cdata->alignmask = crypto_tfm_alg_alignmask(crypto_acomp_tfm(cdata->async.s)); 
 	
 	init_completion(&cdata->async.result.completion);
 	
@@ -461,7 +460,7 @@ int cryptodev_compr_init(struct compr_data *cdata, const char *alg_name)
 	
 	acomp_request_set_callback(cdata->async.request,
 			CRYPTO_TFM_REQ_MAY_BACKLOG,
-			cryptodev_complete, &cdata->async.result)
+			cryptodev_complete, &cdata->async.result);
 
 	cdata->init = 1;
 	return 0;

--- a/cryptlib.h
+++ b/cryptlib.h
@@ -101,6 +101,27 @@ int cryptodev_hash_reset(struct hash_data *hdata);
 void cryptodev_hash_deinit(struct hash_data *hdata);
 int cryptodev_hash_init(struct hash_data *hdata, const char *alg_name,
 			int hmac_mode, void *mackey, size_t mackeylen);
+			
+/* Compression */
+struct compr_data {
+	int init; /* 0 uninitialized */
+	int alignmask;
+	struct {
+		/* block ciphers */
+		struct crypto_acomp *s;
+		struct acomp_req *request;
+		struct cryptodev_result result;
+	} async;
+};
+
+void cryptodev_compr_deinit(struct compr_data *cdata);
+int cryptodev_compr_init(struct compr_data *cdata, const char *alg_name);
+ssize_t cryptodev_compr_compress(struct compr_data *cdata,
+		const struct scatterlist *src, struct scatterlist *dst,
+		size_t len);
+ssize_t cryptodev_compr_decompress(struct compr_data *cdata,
+		const struct scatterlist *src, struct scatterlist *dst,
+		size_t len)
 
 
 #endif

--- a/cryptlib.h
+++ b/cryptlib.h
@@ -118,10 +118,10 @@ void cryptodev_compr_deinit(struct compr_data *cdata);
 int cryptodev_compr_init(struct compr_data *cdata, const char *alg_name);
 ssize_t cryptodev_compr_compress(struct compr_data *cdata,
 		const struct scatterlist *src, struct scatterlist *dst,
-		size_t len);
+		size_t slen, size_t dlen);
 ssize_t cryptodev_compr_decompress(struct compr_data *cdata,
 		const struct scatterlist *src, struct scatterlist *dst,
-		size_t len);
+		size_t slen, size_t dlen);
 
 
 #endif

--- a/cryptlib.h
+++ b/cryptlib.h
@@ -121,7 +121,7 @@ ssize_t cryptodev_compr_compress(struct compr_data *cdata,
 		size_t len);
 ssize_t cryptodev_compr_decompress(struct compr_data *cdata,
 		const struct scatterlist *src, struct scatterlist *dst,
-		size_t len)
+		size_t len);
 
 
 #endif

--- a/crypto/cryptodev.h
+++ b/crypto/cryptodev.h
@@ -42,6 +42,7 @@ enum cryptodev_crypto_op_t {
 	CRYPTO_AES_XTS = 22,
 	CRYPTO_AES_ECB = 23,
 	CRYPTO_AES_GCM = 50,
+	CRYPTO_842 = 65,
 
 	CRYPTO_CAMELLIA_CBC = 101,
 	CRYPTO_RIPEMD160,
@@ -78,10 +79,11 @@ enum cryptodev_crypto_op_t {
 
 /* input of CIOCGSESSION */
 struct session_op {
-	/* Specify either cipher or mac
+	/* Specify cipher, mac or compr
 	 */
 	__u32	cipher;		/* cryptodev_crypto_op_t */
 	__u32	mac;		/* cryptodev_crypto_op_t */
+	__u32	compr;		/* cryptodev_crypto_op_t */
 
 	__u32	keylen;
 	__u8	__user *key;

--- a/crypto/cryptodev.h
+++ b/crypto/cryptodev.h
@@ -43,6 +43,7 @@ enum cryptodev_crypto_op_t {
 	CRYPTO_AES_ECB = 23,
 	CRYPTO_AES_GCM = 50,
 	CRYPTO_842 = 65,
+	CRYPTO_LZO = 66,
 
 	CRYPTO_CAMELLIA_CBC = 101,
 	CRYPTO_RIPEMD160,

--- a/crypto/cryptodev.h
+++ b/crypto/cryptodev.h
@@ -125,6 +125,7 @@ struct crypt_op {
 	__u16	op;		/* COP_ENCRYPT or COP_DECRYPT */
 	__u16	flags;		/* see COP_FLAG_* */
 	__u32	len;		/* length of source data */
+	__u32	dlen;		/* length of output data */
 	__u8	__user *src;	/* source data */
 	__u8	__user *dst;	/* pointer to output data */
 	/* pointer to output data for hash/MAC operations */

--- a/crypto/cryptodev.h
+++ b/crypto/cryptodev.h
@@ -101,7 +101,7 @@ struct session_info_op {
 	struct alg_info {
 		char cra_name[CRYPTODEV_MAX_ALG_NAME];
 		char cra_driver_name[CRYPTODEV_MAX_ALG_NAME];
-	} cipher_info, hash_info;
+	} cipher_info, hash_info, compr_info;
 
 	__u16	alignmask;	/* alignment constraints */
 	__u32   flags;          /* SIOP_FLAGS_* */

--- a/cryptodev_int.h
+++ b/cryptodev_int.h
@@ -52,6 +52,7 @@ struct compat_session_op {
 	 */
 	uint32_t	cipher;		/* cryptodev_crypto_op_t */
 	uint32_t	mac;		/* cryptodev_crypto_op_t */
+	uint32_t	compr;		/* cryptodev_crypto_op_t */
 
 	uint32_t	keylen;
 	compat_uptr_t	key;		/* pointer to key data */
@@ -123,6 +124,7 @@ struct csession {
 	struct mutex sem;
 	struct cipher_data cdata;
 	struct hash_data hdata;
+	struct compr_data comprdata;
 	uint32_t sid;
 	uint32_t alignmask;
 

--- a/examples/842.c
+++ b/examples/842.c
@@ -117,6 +117,13 @@ main()
 	
 	c842_ctx_deinit(&ctx);
 
+	printf("Raw data:\n");
+	for (i = 0; i < 8; i++) {
+		printf("%02x:", input[i]);
+	}
+	printf("\n");
+
+
 	printf("Compressed result:\n");
 	for (i = 0; i < 16; i++) {
 		printf("%02x:", output[i]);

--- a/examples/842.c
+++ b/examples/842.c
@@ -88,15 +88,57 @@ int c842_compress(struct cryptodev_ctx* ctx, const void* input, void* output, si
 	return 0;
 }
 
+int c842_decompress(struct cryptodev_ctx* ctx, const void* input, void* output, size_t size)
+{
+	struct crypt_op cryp;
+	void* p;
+	
+	/* check input and output alignment */
+	if (ctx->alignmask) {
+		p = (void*)(((unsigned long)input + ctx->alignmask) & ~ctx->alignmask);
+		if (input != p) {
+			fprintf(stderr, "input is not aligned\n");
+			return -1;
+		}
+
+		p = (void*)(((unsigned long)output + ctx->alignmask) & ~ctx->alignmask);
+		if (output != p) {
+			fprintf(stderr, "output is not aligned\n");
+			return -1;
+		}
+	}
+
+	memset(&cryp, 0, sizeof(cryp));
+
+	/* Encrypt data.in to data.encrypted */
+	cryp.ses = ctx->sess.ses;
+	cryp.len = size;
+	cryp.dlen = size;
+	cryp.src = (void*)input;
+	cryp.dst = output;
+	cryp.op = COP_DECRYPT;
+	if (ioctl(ctx->cfd, CIOCCRYPT, &cryp)) {
+		perror("ioctl(CIOCCRYPT)");
+		return -1;
+	}
+
+	return 0;
+}
+
 int
 main()
 {
 	int cfd = -1, i;
 	struct cryptodev_ctx ctx;
 	uint8_t output[16];
-	char input[] = "0011223\x0a";
+	char input[8];
+	char decompressed[32];
+	char tmp[] = "0011223\x0a";
 
-	memset (output, 0, 16);
+	memset(input, 0, 8);
+	memset(output, 0, 16);
+	memset(decompressed, 0, 32);
+	strncpy(input, tmp, 8);
 
 	/* Open the crypto device */
 	cfd = open("/dev/crypto", O_RDWR, 0);
@@ -113,9 +155,6 @@ main()
 
 	c842_ctx_init(&ctx, cfd);
 	
-	c842_compress(&ctx, input, output, 8);
-	
-	c842_ctx_deinit(&ctx);
 
 	printf("Raw data:\n");
 	for (i = 0; i < 8; i++) {
@@ -124,11 +163,26 @@ main()
 	printf("\n");
 
 
+	c842_compress(&ctx, input, output, 8);
+
 	printf("Compressed result:\n");
 	for (i = 0; i < 16; i++) {
 		printf("%02x:", output[i]);
 	}
 	printf("\n");
+
+	c842_decompress(&ctx, output, decompressed, 16);
+
+	printf("Restored raw data:\n");
+	for (i = 0; i < 16; i++) {
+		printf("%02x:", decompressed[i]);
+	}
+	printf("\n");
+
+	c842_ctx_deinit(&ctx);
+
+
+
 
 	/* Close the original descriptor */
 	if (close(cfd)) {

--- a/examples/842.h
+++ b/examples/842.h
@@ -1,0 +1,16 @@
+#ifndef c842_H
+# define c842_H
+
+#include <stdint.h>
+
+struct cryptodev_ctx {
+	int cfd;
+	struct session_op sess;
+	uint16_t alignmask;
+};
+
+int c842_ctx_init(struct cryptodev_ctx* ctx, int cfd);
+void c842_ctx_deinit(struct cryptodev_ctx* ctx) ;
+int c842_compress(struct cryptodev_ctx* ctx, const void* input, void* output, size_t size);
+
+#endif

--- a/examples/lzo.c
+++ b/examples/lzo.c
@@ -79,6 +79,7 @@ int lzo_compress(struct cryptodev_ctx* ctx, const void* input, void* output, siz
 	/* Encrypt data.in to data.encrypted */
 	cryp.ses = ctx->sess.ses;
 	cryp.len = size;
+	cryp.dlen = size + 8;
 	cryp.src = (void*)input;
 	cryp.dst = output;
 	cryp.op = COP_ENCRYPT;

--- a/examples/lzo.c
+++ b/examples/lzo.c
@@ -73,7 +73,7 @@ int lzo_compress(struct cryptodev_ctx* ctx, const void* input, void* output, siz
 
 	memset(&cryp, 0, sizeof(cryp));
 
-	/* Encrypt data.in to data.encrypted */
+	/* Compress cryp.src to cryp.dst */
 	cryp.ses = ctx->sess.ses;
 	cryp.len = size;
 	cryp.dlen = size + 8;
@@ -88,15 +88,55 @@ int lzo_compress(struct cryptodev_ctx* ctx, const void* input, void* output, siz
 	return 0;
 }
 
+int lzo_decompress(struct cryptodev_ctx* ctx, const void* input, void* output, size_t size)
+{
+	struct crypt_op cryp;
+	void* p;
+	
+	/* check input and output alignment */
+	if (ctx->alignmask) {
+		p = (void*)(((unsigned long)input + ctx->alignmask) & ~ctx->alignmask);
+		if (input != p) {
+			fprintf(stderr, "input is not aligned\n");
+			return -1;
+		}
+
+		p = (void*)(((unsigned long)output + ctx->alignmask) & ~ctx->alignmask);
+		if (output != p) {
+			fprintf(stderr, "output is not aligned\n");
+			return -1;
+		}
+	}
+
+	memset(&cryp, 0, sizeof(cryp));
+
+	/* Compress cryp.src to cryp.dst */
+	cryp.ses = ctx->sess.ses;
+	cryp.len = size;
+	cryp.dlen = size*2;
+	cryp.src = (void*)input;
+	cryp.dst = output;
+	cryp.op = COP_DECRYPT;
+	if (ioctl(ctx->cfd, CIOCCRYPT, &cryp)) {
+		perror("ioctl(CIOCCRYPT)");
+		return -1;
+	}
+
+	return 0;
+}
+
 int
 main()
 {
 	int cfd = -1, i;
 	struct cryptodev_ctx ctx;
 	uint8_t output[64];
-	char input[] = "The quick brown fox jumps over the lazy dog";
+	char input[64];
+	char tmp[] = "The quick brown fox jumps over the lazy dog";
 
-	memset (output, 0, 64);
+	memset(input, 0, 64);
+	memset(output, 0, 64);
+	strncpy(input, tmp, sizeof input - 1);
 
 	/* Open the crypto device */
 	cfd = open("/dev/crypto", O_RDWR, 0);
@@ -112,10 +152,6 @@ main()
 	}
 
 	lzo_ctx_init(&ctx, cfd);
-	
-	lzo_compress(&ctx, input, output, strlen(input));
-	
-	lzo_ctx_deinit(&ctx);
 
 	printf("Raw data:\n");
 	for (i = 0; i < strlen(input); i++) {
@@ -123,12 +159,15 @@ main()
 	}
 	printf("\n");
 
+	lzo_compress(&ctx, input, output, strlen(input));
 
 	printf("Compressed result:\n");
 	for (i = 0; i < 64; i++) {
 		printf("%02x:", output[i]);
 	}
 	printf("\n");
+
+	lzo_ctx_deinit(&ctx);
 
 	/* Close the original descriptor */
 	if (close(cfd)) {

--- a/examples/lzo.c
+++ b/examples/lzo.c
@@ -1,0 +1,139 @@
+/*
+ * Demo on how to use /dev/crypto device for ciphering.
+ *
+ * Placed under public domain.
+ *
+ */
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <crypto/cryptodev.h>
+#include "lzo.h"
+
+int lzo_ctx_init(struct cryptodev_ctx* ctx, int cfd)
+{
+#ifdef CIOCGSESSINFO
+	struct session_info_op siop;
+#endif
+
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->cfd = cfd;
+
+	ctx->sess.compr = CRYPTO_LZO;
+
+	if (ioctl(ctx->cfd, CIOCGSESSION, &ctx->sess)) {
+		perror("ioctl(CIOCGSESSION)");
+		return -1;
+	}
+
+#ifdef CIOCGSESSINFO
+	siop.ses = ctx->sess.ses;
+	if (ioctl(ctx->cfd, CIOCGSESSINFO, &siop)) {
+		perror("ioctl(CIOCGSESSINFO)");
+		return -1;
+	}
+	printf("Got %s with driver %s\n",
+			siop.compr_info.cra_name, siop.compr_info.cra_driver_name);
+	if (!(siop.flags & SIOP_FLAG_KERNEL_DRIVER_ONLY)) {
+		printf("Note: This is not an accelerated cipher\n");
+	}
+	printf("Alignmask is %x\n", (unsigned int)siop.alignmask);
+	ctx->alignmask = siop.alignmask;
+#endif
+	return 0;
+}
+
+void lzo_ctx_deinit(struct cryptodev_ctx* ctx) 
+{
+	if (ioctl(ctx->cfd, CIOCFSESSION, &ctx->sess.ses)) {
+		perror("ioctl(CIOCFSESSION)");
+	}
+}
+
+int lzo_compress(struct cryptodev_ctx* ctx, const void* input, void* output, size_t size)
+{
+	struct crypt_op cryp;
+	void* p;
+	
+	/* check input and output alignment */
+	if (ctx->alignmask) {
+		p = (void*)(((unsigned long)input + ctx->alignmask) & ~ctx->alignmask);
+		if (input != p) {
+			fprintf(stderr, "input is not aligned\n");
+			return -1;
+		}
+
+		p = (void*)(((unsigned long)output + ctx->alignmask) & ~ctx->alignmask);
+		if (output != p) {
+			fprintf(stderr, "output is not aligned\n");
+			return -1;
+		}
+	}
+
+	printf("alignment checked successfully\n");
+
+	memset(&cryp, 0, sizeof(cryp));
+
+	/* Encrypt data.in to data.encrypted */
+	cryp.ses = ctx->sess.ses;
+	cryp.len = size;
+	cryp.src = (void*)input;
+	cryp.dst = output;
+	cryp.op = COP_ENCRYPT;
+	printf("about to issue CIOCCRYPT\n");
+	if (ioctl(ctx->cfd, CIOCCRYPT, &cryp)) {
+		perror("ioctl(CIOCCRYPT)");
+		return -1;
+	}
+
+	return 0;
+}
+
+int
+main()
+{
+	int cfd = -1, i;
+	struct cryptodev_ctx ctx;
+	uint8_t output[128];
+	char input[] = "The quick brown fox jumps over the lazy dog";
+
+	memset (output, 0, 128);
+
+	/* Open the crypto device */
+	cfd = open("/dev/crypto", O_RDWR, 0);
+	if (cfd < 0) {
+		perror("open(/dev/crypto)");
+		return 1;
+	}
+
+	/* Set close-on-exec (not really neede here) */
+	if (fcntl(cfd, F_SETFD, 1) == -1) {
+		perror("fcntl(F_SETFD)");
+		return 1;
+	}
+
+	lzo_ctx_init(&ctx, cfd);
+
+	printf("lzo_ctx_init returned successfully\n");
+	
+	lzo_compress(&ctx, input, output, strlen(input));
+	
+	lzo_ctx_deinit(&ctx);
+
+	printf("lzo compress: ");
+	for (i = 0; i < 128; i++) {
+		printf("%02x:", output[i]);
+	}
+	printf("\n");
+
+	/* Close the original descriptor */
+	if (close(cfd)) {
+		perror("close(cfd)");
+		return 1;
+	}
+
+	return 0;
+}
+

--- a/examples/lzo.c
+++ b/examples/lzo.c
@@ -117,6 +117,13 @@ main()
 	
 	lzo_ctx_deinit(&ctx);
 
+	printf("Raw data:\n");
+	for (i = 0; i < strlen(input); i++) {
+		printf("%02x:", input[i]);
+	}
+	printf("\n");
+
+
 	printf("Compressed result:\n");
 	for (i = 0; i < 64; i++) {
 		printf("%02x:", output[i]);

--- a/examples/lzo.h
+++ b/examples/lzo.h
@@ -1,0 +1,16 @@
+#ifndef LZO_H
+# define LZO_H
+
+#include <stdint.h>
+
+struct cryptodev_ctx {
+	int cfd;
+	struct session_op sess;
+	uint16_t alignmask;
+};
+
+int lzo_ctx_init(struct cryptodev_ctx* ctx, int cfd);
+void lzo_ctx_deinit(struct cryptodev_ctx* ctx) ;
+int lzo_compress(struct cryptodev_ctx* ctx, const void* input, void* output, size_t size);
+
+#endif

--- a/ioctl.c
+++ b/ioctl.c
@@ -368,7 +368,7 @@ crypto_destroy_session(struct csession *ses_ptr)
 	ddebug(2, "Removed session 0x%08X", ses_ptr->sid);
 	cryptodev_cipher_deinit(&ses_ptr->cdata);
 	cryptodev_hash_deinit(&ses_ptr->hdata);
-	cryptodev_compr_deinit(&ses_new->comprdata);
+	cryptodev_compr_deinit(&ses_ptr->comprdata);
 	ddebug(2, "freeing space for %d user pages", ses_ptr->array_size);
 	kfree(ses_ptr->pages);
 	kfree(ses_ptr->sg);

--- a/main.c
+++ b/main.c
@@ -148,7 +148,7 @@ __crypto_run_std(struct csession *ses_ptr, struct crypt_op *cop)
 
 		sg_init_one(&sg, data, current_len);
 
-		ret = hash_n_crypt(ses_ptr, cop, &sg, &sg, current_len);
+		ret = hash_n_crypt(ses_ptr, cop, &sg, &sg, current_len, current_len);
 
 		if (unlikely(ret)) {
 		        derr(1, "hash_n_crypt failed.");

--- a/main.c
+++ b/main.c
@@ -258,6 +258,10 @@ int crypto_run(struct fcrypt *fcr, struct kernel_crypt_op *kcop)
 		}
 
 		if (cop->flags & COP_FLAG_NO_ZC)
+			if (unlikely(ses_ptr->comprdata.init != 0)) {
+				derr(0, "Compression algorithms are only supported through the zero-copy API", ret);
+				goto out_unlock;
+			}
 			ret = __crypto_run_std(ses_ptr, &kcop->cop);
 		else
 			ret = __crypto_run_zc(ses_ptr, kcop);

--- a/main.c
+++ b/main.c
@@ -257,14 +257,15 @@ int crypto_run(struct fcrypt *fcr, struct kernel_crypt_op *kcop)
 			}
 		}
 
-		if (cop->flags & COP_FLAG_NO_ZC)
+		if (cop->flags & COP_FLAG_NO_ZC) {
 			if (unlikely(ses_ptr->comprdata.init != 0)) {
-				derr(0, "Compression algorithms are only supported through the zero-copy API", ret);
+				derr(0, "Compression algorithms are only supported through the zero-copy API");
 				goto out_unlock;
 			}
 			ret = __crypto_run_std(ses_ptr, &kcop->cop);
-		else
+		} else {
 			ret = __crypto_run_zc(ses_ptr, kcop);
+		}
 		if (unlikely(ret))
 			goto out_unlock;
 	}

--- a/main.c
+++ b/main.c
@@ -77,6 +77,13 @@ hash_n_crypt(struct csession *ses_ptr, struct crypt_op *cop,
 			if (unlikely(ret))
 				goto out_err;
 		}
+		if (ses_ptr->comprdata.init != 0) {
+			ret = cryptodev_compr_compress(&ses_ptr->comprdata,
+							src_sg, dst_sg, len);
+
+			if (unlikely(ret))
+				goto out_err;
+		}
 	} else {
 		if (ses_ptr->cdata.init != 0) {
 			ret = cryptodev_cipher_decrypt(&ses_ptr->cdata,
@@ -89,6 +96,13 @@ hash_n_crypt(struct csession *ses_ptr, struct crypt_op *cop,
 		if (ses_ptr->hdata.init != 0) {
 			ret = cryptodev_hash_update(&ses_ptr->hdata,
 								dst_sg, len);
+			if (unlikely(ret))
+				goto out_err;
+		}
+		if (ses_ptr->comprdata.init != 0) {
+			ret = cryptodev_compr_decompress(&ses_ptr->comprdata,
+							src_sg, dst_sg, len);
+
 			if (unlikely(ret))
 				goto out_err;
 		}


### PR DESCRIPTION
The cryptodev-linux kernel module has been extended to support compression-type crypto functions. At the current state, both LZO and the IBM 842 algorithm are supported and example programs are provided as well.