### PR TITLE
ioctl.c: Fix build with linux 4.13

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -1124,7 +1124,7 @@ static struct ctl_table verbosity_ctl_dir[] = {
 		.mode           = 0644,
 		.proc_handler   = proc_dointvec,
 	},
-	{0, },
+	{},
 };
 
 static struct ctl_table verbosity_ctl_root[] = {
@@ -1133,7 +1133,7 @@ static struct ctl_table verbosity_ctl_root[] = {
 		.mode           = 0555,
 		.child          = verbosity_ctl_dir,
 	},
-	{0, },
+	{},
 };
 static struct ctl_table_header *verbosity_sysctl_header;
 static int __init init_cryptodev(void)


### PR DESCRIPTION
git/ioctl.c:1127:3: error: positional initialization of field in 'struct' declared with 'designated_init' attribute [-Werror=designated-init]
   {0, },
    ^
note: (near initialization for 'verbosity_ctl_dir[1]')
git/ioctl.c:1136:3: error: positional initialization of field in 'struct' declared with 'designated_init' attribute [-Werror=designated-init]
   {0, },
    ^
Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>