### PR TITLE
Fix memory leak during crypto_create_session()

### DIFF
--- a/cryptlib.c
+++ b/cryptlib.c
@@ -406,6 +406,8 @@ int cryptodev_hash_reset(struct hash_data *hdata)
 		return ret;
 	}
 
+	hdata->reset = 1;
+
 	return 0;
 
 }

--- a/cryptlib.h
+++ b/cryptlib.h
@@ -85,6 +85,7 @@ static inline void cryptodev_cipher_get_iv(struct cipher_data *cdata,
 /* Hash */
 struct hash_data {
 	int init; /* 0 uninitialized */
+	int reset; /* 0 was not reset */
 	int digestsize;
 	int alignmask;
 	struct {

--- a/ioctl.c
+++ b/ioctl.c
@@ -278,11 +278,6 @@ crypto_create_session(struct fcrypt *fcr, struct session_op *sop)
 			ret = -EINVAL;
 			goto session_error;
 		}
-
-		ret = cryptodev_hash_reset(&ses_new->hdata);
-		if (ret != 0) {
-			goto session_error;
-		}
 	}
 
 	ses_new->alignmask = max(ses_new->cdata.alignmask,

--- a/main.c
+++ b/main.c
@@ -64,6 +64,12 @@ hash_n_crypt(struct csession *ses_ptr, struct crypt_op *cop,
 	 * we should introduce a flag to switch... TBD later on.
 	 */
 	if (cop->op == COP_ENCRYPT) {
+		if (ses_ptr->hdata.init != 0 && ses_ptr->hdata.reset == 0) {
+			ret = cryptodev_hash_reset(&ses_ptr->hdata);
+			if (unlikely(ret))
+				goto out_err;
+		}
+
 		if (ses_ptr->hdata.init != 0) {
 			ret = cryptodev_hash_update(&ses_ptr->hdata,
 							src_sg, len);


### PR DESCRIPTION
Currently, crypto_create_session() calls cryptodev_hash_reset(), which
calls the crypto API function crypto_ahash_init(). This is an error,
because crypto_finish_session() does not call the crypto API function
crypto_ahash_final().

For the Renesas rcar3 crypto API driver, crypto_ahash_init() allocates
memory, and crypto_ahash_final() frees memory. The current behaviour
causes a memory leak every time a session is opened and closed without
executing a hash operation.

This commit moves the cryptodev_hash_reset() call into hash_n_crypt().
This fixes the issue and keeps the logic of the operation.

Fixes: 93261cc0474c ("remove code duplication in cryptodev_hash_init")
Signed-off-by: Kirill Marinushkin <kmarinushkin@de.adit-jv.com>