### PR TITLE
Port tests to openssl 1.1

### DIFF
--- a/tests/openssl_wrapper.c
+++ b/tests/openssl_wrapper.c
@@ -4,6 +4,7 @@
 #include <openssl/aes.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
+#include <openssl/opensslv.h>
 
 //#define DEBUG
 
@@ -23,10 +24,17 @@ enum ctx_type {
 	ctx_type_md,
 };
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+union openssl_ctx {
+	HMAC_CTX *hmac;
+	EVP_MD_CTX *md;
+};
+#else
 union openssl_ctx {
 	HMAC_CTX hmac;
 	EVP_MD_CTX md;
 };
+#endif
 
 struct ctx_mapping {
 	__u32 ses;
@@ -63,6 +71,16 @@ static void remove_mapping(__u32 ses)
 	switch (mapping->type) {
 	case ctx_type_none:
 		break;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	case ctx_type_hmac:
+		dbgp("%s: calling HMAC_CTX_free\n", __func__);
+		HMAC_CTX_free(mapping->ctx.hmac);
+		break;
+	case ctx_type_md:
+		dbgp("%s: calling EVP_MD_CTX_free\n", __func__);
+		EVP_MD_CTX_free(mapping->ctx.md);
+		break;
+#else
 	case ctx_type_hmac:
 		dbgp("%s: calling HMAC_CTX_cleanup\n", __func__);
 		HMAC_CTX_cleanup(&mapping->ctx.hmac);
@@ -71,6 +89,7 @@ static void remove_mapping(__u32 ses)
 		dbgp("%s: calling EVP_MD_CTX_cleanup\n", __func__);
 		EVP_MD_CTX_cleanup(&mapping->ctx.md);
 		break;
+#endif
 	}
 	memset(mapping, 0, sizeof(*mapping));
 }
@@ -127,10 +146,17 @@ static int openssl_hmac(struct session_op *sess, struct crypt_op *cop)
 
 		mapping->ses = sess->ses;
 		mapping->type = ctx_type_hmac;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+		ctx = mapping->ctx.hmac;
+
+		dbgp("calling HMAC_CTX_new");
+		ctx = HMAC_CTX_new();
+#else
 		ctx = &mapping->ctx.hmac;
 
 		dbgp("calling HMAC_CTX_init");
 		HMAC_CTX_init(ctx);
+#endif
 		dbgp("calling HMAC_Init_ex");
 		if (!HMAC_Init_ex(ctx, sess->mackey, sess->mackeylen,
 				sess_to_evp_md(sess), NULL)) {
@@ -172,10 +198,17 @@ static int openssl_md(struct session_op *sess, struct crypt_op *cop)
 
 		mapping->ses = sess->ses;
 		mapping->type = ctx_type_md;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+		ctx = mapping->ctx.md;
+
+		dbgp("calling EVP_MD_CTX_new");
+		ctx = EVP_MD_CTX_new();
+#else
 		ctx = &mapping->ctx.md;
 
 		dbgp("calling EVP_MD_CTX_init");
 		EVP_MD_CTX_init(ctx);
+#endif
 		dbgp("calling EVP_DigestInit");
 		EVP_DigestInit(ctx, sess_to_evp_md(sess));
 	}


### PR DESCRIPTION
This fixes API compaitbility errors that happen when building with openssl 1.1.0 and later.