### PR TITLE
Enable COP_FLAG_NO_ZC at unaligned case

### DIFF
--- a/main.c
+++ b/main.c
@@ -222,17 +222,17 @@ int crypto_run(struct fcrypt *fcr, struct kernel_crypt_op *kcop)
 	}
 
 	if (likely(cop->len)) {
-		if (cop->flags & COP_FLAG_NO_ZC) {
+		if (!(cop->flags & COP_FLAG_NO_ZC)) {
 			if (unlikely(ses_ptr->alignmask && !IS_ALIGNED((unsigned long)cop->src, ses_ptr->alignmask))) {
 				dwarning(2, "source address %p is not %d byte aligned - disabling zero copy",
 						cop->src, ses_ptr->alignmask + 1);
-				cop->flags &= ~COP_FLAG_NO_ZC;
+				cop->flags |= COP_FLAG_NO_ZC;
 			}
 
 			if (unlikely(ses_ptr->alignmask && !IS_ALIGNED((unsigned long)cop->dst, ses_ptr->alignmask))) {
 				dwarning(2, "destination address %p is not %d byte aligned - disabling zero copy",
 						cop->dst, ses_ptr->alignmask + 1);
-				cop->flags &= ~COP_FLAG_NO_ZC;
+				cop->flags |= COP_FLAG_NO_ZC;
 			}
 		}
 


### PR DESCRIPTION
COP_FLAG_NO_ZC means "no zero copy". So when we find unaligned
case, we need to enable this flag instead of disabling it.