### PR TITLE
Fix alignment value in IS_ALIGNED

### DIFF
--- a/authenc.c
+++ b/authenc.c
@@ -62,7 +62,7 @@ static int get_userbuf_tls(struct csession *ses, struct kernel_crypt_auth_op *kc
 		return -EINVAL;
 
 	if (ses->alignmask) {
-		if (!IS_ALIGNED((unsigned long)caop->dst, ses->alignmask))
+		if (!IS_ALIGNED((unsigned long)caop->dst, ses->alignmask + 1))
 			dwarning(2, "careful - source address %p is not %d byte aligned",
 					caop->dst, ses->alignmask + 1);
 	}
@@ -116,10 +116,10 @@ static int get_userbuf_srtp(struct csession *ses, struct kernel_crypt_auth_op *k
 	}
 
 	if (ses->alignmask) {
-		if (!IS_ALIGNED((unsigned long)caop->dst, ses->alignmask))
+		if (!IS_ALIGNED((unsigned long)caop->dst, ses->alignmask + 1))
 			dwarning(2, "careful - source address %p is not %d byte aligned",
 					caop->dst, ses->alignmask + 1);
-		if (!IS_ALIGNED((unsigned long)caop->auth_src, ses->alignmask))
+		if (!IS_ALIGNED((unsigned long)caop->auth_src, ses->alignmask + 1))
 			dwarning(2, "careful - source address %p is not %d byte aligned",
 					caop->auth_src, ses->alignmask + 1);
 	}

--- a/main.c
+++ b/main.c
@@ -223,13 +223,13 @@ int crypto_run(struct fcrypt *fcr, struct kernel_crypt_op *kcop)
 
 	if (likely(cop->len)) {
 		if (!(cop->flags & COP_FLAG_NO_ZC)) {
-			if (unlikely(ses_ptr->alignmask && !IS_ALIGNED((unsigned long)cop->src, ses_ptr->alignmask))) {
+			if (unlikely(ses_ptr->alignmask && !IS_ALIGNED((unsigned long)cop->src, ses_ptr->alignmask + 1))) {
 				dwarning(2, "source address %p is not %d byte aligned - disabling zero copy",
 						cop->src, ses_ptr->alignmask + 1);
 				cop->flags |= COP_FLAG_NO_ZC;
 			}
 
-			if (unlikely(ses_ptr->alignmask && !IS_ALIGNED((unsigned long)cop->dst, ses_ptr->alignmask))) {
+			if (unlikely(ses_ptr->alignmask && !IS_ALIGNED((unsigned long)cop->dst, ses_ptr->alignmask + 1))) {
 				dwarning(2, "destination address %p is not %d byte aligned - disabling zero copy",
 						cop->dst, ses_ptr->alignmask + 1);
 				cop->flags |= COP_FLAG_NO_ZC;


### PR DESCRIPTION
IS_ALIGNED() requires us to pass expected alignment, not alignmask.
Therefore instead of alignmask, we need to put alignmask + 1.