### PR TITLE
ioctl.c: Fix build with linux 4.17

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -828,7 +828,11 @@ cryptodev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg_)
 		fd = clonefd(filp);
 		ret = put_user(fd, p);
 		if (unlikely(ret)) {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0))
 			sys_close(fd);
+#else
+			ksys_close(fd);
+#endif
 			return ret;
 		}
 		return ret;


### PR DESCRIPTION
Since kernel 4.17-rc1, sys_* syscalls can no longer be called directly:
819671ff849b ("syscalls: define and explain goal to not call syscalls in the kernel")

Since cryptodev uses sys_close() - and this has been removed in commit:
2ca2a09d6215 ("fs: add ksys_close() wrapper; remove in-kernel calls to sys_close()")
cryptodev has to be updated to use the ksys_close() wrapper.

Signed-off-by: Horia Geantă <horia.geanta@nxp.com>