### PR TITLE
enabled the support for TLS1.1 - AES128-SHA1 - AES256-SHA1

### DIFF
--- a/crypto/cryptodev.h
+++ b/crypto/cryptodev.h
@@ -51,6 +51,8 @@ enum cryptodev_crypto_op_t {
 	CRYPTO_SHA2_384,
 	CRYPTO_SHA2_512,
 	CRYPTO_SHA2_224_HMAC,
+	CRYPTO_TLS11_AES_CBC_HMAC_SHA1,
+	CRYPTO_TLS12_AES_CBC_HMAC_SHA256,
 	CRYPTO_ALGORITHM_ALL, /* Keep updated - see below */
 };
 

--- a/ioctl.c
+++ b/ioctl.c
@@ -159,6 +159,16 @@ crypto_create_session(struct fcrypt *fcr, struct session_op *sop)
 		stream = 1;
 		aead = 1;
 		break;
+	case CRYPTO_TLS11_AES_CBC_HMAC_SHA1:
+		alg_name = "tls11(hmac(sha1),cbc(aes))";
+		stream = 0;
+		aead = 1;
+		break;
+	case CRYPTO_TLS12_AES_CBC_HMAC_SHA256:
+		alg_name = "tls12(hmac(sha256),cbc(aes))";
+		stream = 0;
+		aead = 1;
+		break;
 	case CRYPTO_NULL:
 		alg_name = "ecb(cipher_null)";
 		stream = 1;


### PR DESCRIPTION
& TLS1.2 offloads for:
    - AES128-SHA256
    - AES256-SHA256

It requires kernel support for algorithms:

    - tls11(hmac(sha1),cbc(aes))
    - tls12(hmac(sha256),cbc(aes))

to be provided either in software or accelerated by hardware
such as NXP B*, P* and T* platforms.

Signed-off-by: Pankaj Gupta <pankaj.gupta@nxp.com>