### PR TITLE
Fix VLA usage in authenc.c

### DIFF
--- a/authenc.c
+++ b/authenc.c
@@ -314,7 +314,8 @@ static void read_tls_hash(struct scatterlist *dst_sg, int len, void *hash, int h
 
 static int pad_record(struct scatterlist *dst_sg, int len, int block_size)
 {
-	uint8_t pad[block_size];
+	uint8_t *pad;
+	pad = kmalloc_array(block_size,sizeof(*pad),GFP_KERNEL);
 	int pad_size = block_size - (len % block_size);
 
 	memset(pad, pad_size - 1, pad_size);


### PR DESCRIPTION
Linux no longer allows VLA use in the kernel, requiring declaration
of allocation sizes to be up-front. Convert `pad[block_size]` to
`kmalloc_array(block_size,...)` which fixes the "alloca is no
longer permitted in linux" build error.