### PR TITLE
Fix build for Linux 5.8-rc1

### DIFF
--- a/zc.c
+++ b/zc.c
@@ -58,7 +58,11 @@ int __get_userbuf(uint8_t __user *addr, uint32_t len, int write,
 		return 0;
 	}
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 	down_read(&mm->mmap_sem);
+#else
+	mmap_read_lock(mm);
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0))
 	ret = get_user_pages(task, mm,
 			(unsigned long)addr, pgcount, write, 0, pg, NULL);
@@ -74,7 +78,11 @@ int __get_userbuf(uint8_t __user *addr, uint32_t len, int write,
 			(unsigned long)addr, pgcount, write ? FOLL_WRITE : 0,
 			pg, NULL, NULL);
 #endif
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
 	up_read(&mm->mmap_sem);
+#else
+	mmap_read_unlock(mm);
+#endif
 	if (ret != pgcount)
 		return -EINVAL;
 


### PR DESCRIPTION
Fixes the build for Linux 5.8-rc1 due to the new mmap locking API.

See also:
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9740ca4e95b43b91a4a848694a20d01ba6818f7b
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=da1c55f1b272f4bd54671d459b39ea7b54944ef9
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d8ed45c5dcd455fc5848d47f86883a1b872ac0d0
