### PR TITLE
Fix for change in Kernel 4.4.168

### DIFF
--- a/zc.c
+++ b/zc.c
@@ -63,9 +63,12 @@ int __get_userbuf(uint8_t __user *addr, uint32_t len, int write,
 #else
 	mmap_read_lock(mm);
 #endif
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 168))
 	ret = get_user_pages(task, mm,
 			(unsigned long)addr, pgcount, write, 0, pg, NULL);
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0))
+	ret = get_user_pages(task, mm,
+			(unsigned long)addr, pgcount, write, pg, NULL);
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0))
 	ret = get_user_pages_remote(task, mm,
 			(unsigned long)addr, pgcount, write, 0, pg, NULL);


### PR DESCRIPTION
Fixes #46 -- Kernel 4.4.168 removed the force flag from get_user_pages:
```diff
@@ -1195,19 +1199,17 @@ long __get_user_pages(struct task_struct *tsk, struct mm_struct *mm,
 		      struct vm_area_struct **vmas, int *nonblocking);
 long get_user_pages(struct task_struct *tsk, struct mm_struct *mm,
 		    unsigned long start, unsigned long nr_pages,
-		    int write, int force, struct page **pages,
+		    unsigned int gup_flags, struct page **pages,
 		    struct vm_area_struct **vmas);
```