### PR TITLE
Fix build for Linux 5.11-rc1

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -871,8 +871,10 @@ cryptodev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg_)
 		if (unlikely(ret)) {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0))
 			sys_close(fd);
-#else
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0))
 			ksys_close(fd);
+#else
+			close_fd(fd);
 #endif
 			return ret;
 		}


### PR DESCRIPTION
ksys_close was removed, as far as I can tell, close_fd replaces it.

See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8760c909f54a82aaa6e76da19afe798a0c77c3c3
          https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1572bfdf21d4d50e51941498ffe0b56c2289f783