### PR TITLE
ioctl.c: use close_fd instead of ksys_close on kernel v5.11+

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -871,8 +871,10 @@ cryptodev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg_)
 		if (unlikely(ret)) {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0))
 			sys_close(fd);
-#else
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0))
 			ksys_close(fd);
+#else
+			close_fd(fd);
 #endif
 			return ret;
 		}


### PR DESCRIPTION
ksys_close has been a wrapper calling close_fd for quite some time.
It was removed in 5.11.
Use close_fd instead of ksys_close on kernel v5.11+.

Signed-off-by: Scott Branden <scott.branden@broadcom.com>