### PR TITLE
Add option for INSTALL_MOD_PATH for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ endif
 ifneq ($(CROSS_COMPILE),)
 KERNEL_MAKE_OPTS += CROSS_COMPILE=$(CROSS_COMPILE)
 endif
+ifneq ($(INSTALL_MOD_PATH),)
+KERNEL_MAKE_OPTS += INSTALL_MOD_PATH=$(INSTALL_MOD_PATH)
+endif
 
 build: version.h
 	$(MAKE) $(KERNEL_MAKE_OPTS) modules


### PR DESCRIPTION
INSTALL_MOD_PATH will allow developers to install the module at the
locations other than the default one.

This is useful when a developer cross compiles this module and has to install in a root file-system which is located in an external storage. (Generally a SD card in case of development boards).