### PR TITLE
Add support for xts aes algorithm

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -147,6 +147,9 @@ crypto_create_session(struct fcrypt *fcr, struct session_op *sop)
 	case CRYPTO_AES_ECB:
 		alg_name = "ecb(aes)";
 		break;
+	case CRYPTO_AES_XTS:
+		alg_name = "xts(aes)";
+		break;
 	case CRYPTO_CAMELLIA_CBC:
 		alg_name = "cbc(camellia)";
 		break;


### PR DESCRIPTION
This patch allows to expose the xts aes algorithm using cryptodev-linux.

Signed-off-by: Daniel Kestrel <kestrel1974@t-online.de>

Thanks in advance.