### PR TITLE
Fix potential crash or deadlock in CIOCCPHASH implementation

### DIFF
--- a/cryptlib.c
+++ b/cryptlib.c
@@ -451,7 +451,8 @@ int cryptodev_hash_copy(struct hash_data *dst, struct hash_data *src)
 	void *statedata = NULL;
 	struct crypto_tfm *tfm;
 
-	if (unlikely(src == NULL || dst == NULL)) {
+	if (unlikely(src == NULL || !src->init ||
+		     dst == NULL || !dst->init)) {
 		return -EINVAL;
 	}
 

--- a/cryptodev_int.h
+++ b/cryptodev_int.h
@@ -135,6 +135,10 @@ struct csession {
 };
 
 struct csession *crypto_get_session_by_sid(struct fcrypt *fcr, uint32_t sid);
+int
+crypto_get_sessions_by_sid(struct fcrypt *fcr,
+			   uint32_t sid_1, struct csession **ses_ptr_1,
+			   uint32_t sid_2, struct csession **ses_ptr_2);
 
 static inline void crypto_put_session(struct csession *ses_ptr)
 {


### PR DESCRIPTION
Fix the following bugs in the CIOCCPHASH implementation:

* If either session only has cipher state, it dereferences a null pointer
* If the source and destination session IDs are the same, it self-deadlocks
* Two concurrent calls with opposite source and destination IDs may deadlock
