### PR TITLE
README: rework OpenSSL compilation instructions

### DIFF
--- a/README
+++ b/README
@@ -16,16 +16,9 @@ advantage of /dev/crypto. GnuTLS 3.0.14 or later is recommended.
 
 * OpenSSL:
 
-Note that OpenSSL's cryptodev implementation is outdated, and there
-are issues with it. For that we recommend to use the patches
-below, that we have provided to the openssl project.
-
-http://rt.openssl.org/Ticket/Display.html?id=2770&user=guest&pass=guest
-
-After applying the patches you can add cryptodev support by using the
--DHAVE_CRYPTODEV and -DUSE_CRYPTODEV_DIGESTS flags during compilation.
-Note that the latter flag (digests) may induce a performance penalty
-in some systems. 
+OpenSSL needs -DHAVE_CRYPTODEV and -DUSE_CRYPTODEV_DIGESTS flags
+during compilation. Note that the latter flag (digests) may induce
+a performance penalty in some systems.
 
 
 === Modifying and viewing verbosity at runtime ===


### PR DESCRIPTION
As the patches for OpenSSL are already upstream, remove the obsolete
instructions.

Fixes #62 

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>