### PR TITLE
cryptodev_verbosity: Fix build for Linux 6.4

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -1246,7 +1246,9 @@ static struct ctl_table verbosity_ctl_root[] = {
 	{
 		.procname       = "ioctl",
 		.mode           = 0555,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0))
 		.child          = verbosity_ctl_dir,
+#endif
 	},
 	{},
 };
@@ -1267,7 +1269,11 @@ static int __init init_cryptodev(void)
 		return rc;
 	}
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0))
 	verbosity_sysctl_header = register_sysctl_table(verbosity_ctl_root);
+#else
+	verbosity_sysctl_header = register_sysctl(verbosity_ctl_root->procname, verbosity_ctl_dir);
+#endif
 
 	pr_info(PFX "driver %s loaded.\n", VERSION);
 


### PR DESCRIPTION
register_sysctl_table api is removed in kernel.
migrate to the new api register_sysctl.

child is also removed in linux 6.4 ctl_table struct.