### PR TITLE
Move recent Linux version #ifdefs from v6.4 to v6.5

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -1246,7 +1246,7 @@ static struct ctl_table verbosity_ctl_root[] = {
 	{
 		.procname       = "ioctl",
 		.mode           = 0555,
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
 		.child          = verbosity_ctl_dir,
 #endif
 	},
@@ -1269,7 +1269,7 @@ static int __init init_cryptodev(void)
 		return rc;
 	}
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
 	verbosity_sysctl_header = register_sysctl_table(verbosity_ctl_root);
 #else
 	verbosity_sysctl_header = register_sysctl(verbosity_ctl_root->procname, verbosity_ctl_dir);

--- a/zc.c
+++ b/zc.c
@@ -80,7 +80,7 @@ int __get_userbuf(uint8_t __user *addr, uint32_t len, int write,
 	ret = get_user_pages_remote(task, mm,
 			(unsigned long)addr, pgcount, write ? FOLL_WRITE : 0,
 			pg, NULL, NULL);
-#elif (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0))
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
 	ret = get_user_pages_remote(mm,
 			(unsigned long)addr, pgcount, write ? FOLL_WRITE : 0,
 			pg, NULL, NULL);


### PR DESCRIPTION
The latest commits, meant to fix the build on Linux 6.4, are actually fixing the build for API changes introduced in the merge window of the yet-unreleased Linux 6.5, and actually break the build for Linux 6.4.

In particular, the upstream commits introducing the API changes are the following, which are *not* included in the Linux v6.4 tag:
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=19c4e618a1bc3d0cad1f04c857be8076cb05bbb2
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ca5e863233e8f6acd1792fd85d6bc2729a1b2c10

Change to #ifdef's to v6.5, where they will most likely be included.

CC @jaingaurav2712. PS: I suspect you are running some kernel built from the linux-mainline or linux-next master branch? The version number doesn't get bumped from 6.4 to 6.5 until the actual rc1 release which will likely happen next Sunday, so you are probably running a "Linux 6.4" which is actually "Linux 6.4 + changes planned for 6.5".