### PR TITLE
Fix build for Linux 6.7-rc1

### DIFF
--- a/cryptlib.c
+++ b/cryptlib.c
@@ -381,7 +381,11 @@ int cryptodev_hash_init(struct hash_data *hdata, const char *alg_name,
 	}
 
 	hdata->digestsize = crypto_ahash_digestsize(hdata->async.s);
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0))
 	hdata->alignmask = crypto_ahash_alignmask(hdata->async.s);
+#else
+	hdata->alignmask = 0;
+#endif
 
 	init_completion(&hdata->async.result.completion);
 


### PR DESCRIPTION
Since Linux 6.7-rc1, no ahash algorithms set a nonzero alignmask, and therefore `crypto_ahash_alignmask` has been removed.

See also:
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0f8660c82b79af595b056f6b9f4f227edeb88574
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c626910f3f1bbce6ad18bc613d895d2a089ed95e