### PR TITLE
Fix build for linux 5.10.220

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -933,7 +933,7 @@ cryptodev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg_)
 		if (unlikely(ret)) {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0))
 			sys_close(fd);
-#elif (LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0))
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 220))
 			ksys_close(fd);
 #else
 			close_fd(fd);


### PR DESCRIPTION
The commit previously integrated is 5.11 has now been backported to 5.10.y branch.

https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.10.y&id=1aecdaa7e2c6619a7d2c0a81c8f5c06e52f870f3