### PR TITLE
Fix cryptodev_verbosity sysctl for Linux 6.11-rc1

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -1231,6 +1231,7 @@ cryptodev_deregister(void)
 }
 
 /* ====== Module init/exit ====== */
+static const char verbosity_ctl_path[] = "ioctl";
 static struct ctl_table verbosity_ctl_dir[] = {
 	{
 		.procname       = "cryptodev_verbosity",
@@ -1244,16 +1245,16 @@ static struct ctl_table verbosity_ctl_dir[] = {
 #endif
 };
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
 static struct ctl_table verbosity_ctl_root[] = {
 	{
-		.procname       = "ioctl",
+		.procname       = verbosity_ctl_path,
 		.mode           = 0555,
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
 		.child          = verbosity_ctl_dir,
-#endif
 	},
 	{},
 };
+#endif
 static struct ctl_table_header *verbosity_sysctl_header;
 static int __init init_cryptodev(void)
 {
@@ -1274,7 +1275,7 @@ static int __init init_cryptodev(void)
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
 	verbosity_sysctl_header = register_sysctl_table(verbosity_ctl_root);
 #else
-	verbosity_sysctl_header = register_sysctl(verbosity_ctl_root->procname, verbosity_ctl_dir);
+	verbosity_sysctl_header = register_sysctl(verbosity_ctl_path, verbosity_ctl_dir);
 #endif
 
 	pr_info(PFX "driver %s loaded.\n", VERSION);

--- a/ioctl.c
+++ b/ioctl.c
@@ -1239,7 +1239,9 @@ static struct ctl_table verbosity_ctl_dir[] = {
 		.mode           = 0644,
 		.proc_handler   = proc_dointvec,
 	},
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0))
 	{},
+#endif
 };
 
 static struct ctl_table verbosity_ctl_root[] = {


### PR DESCRIPTION
There has been a long-running Linux kernel effort to get rid of the sentinels of `struct ctl_table`. In Linux 6.11 it has been completed, and registering a sysctl with a sentinel will fail with a dmesg error:

> sysctl table check failed: ioctl/(null) procname is null
> sysctl table check failed: ioctl/(null) No proc_handler

Exclude the sentinels since that version. See also:
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f8a8b94d0698ccc56c44478169c91ca774540d9f
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9edbfe92a0a1355bae1e47c8f542ac0d39f19f8c

Also contains a small refactor intended to make clearer what code is needed for each old kernel version.