### PR TITLE
Use register_sysctl() also on older kernels

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -1245,16 +1245,6 @@ static struct ctl_table verbosity_ctl_dir[] = {
 #endif
 };
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
-static struct ctl_table verbosity_ctl_root[] = {
-	{
-		.procname       = verbosity_ctl_path,
-		.mode           = 0555,
-		.child          = verbosity_ctl_dir,
-	},
-	{},
-};
-#endif
 static struct ctl_table_header *verbosity_sysctl_header;
 static int __init init_cryptodev(void)
 {
@@ -1272,11 +1262,7 @@ static int __init init_cryptodev(void)
 		return rc;
 	}
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
-	verbosity_sysctl_header = register_sysctl_table(verbosity_ctl_root);
-#else
 	verbosity_sysctl_header = register_sysctl(verbosity_ctl_path, verbosity_ctl_dir);
-#endif
 
 	pr_info(PFX "driver %s loaded.\n", VERSION);
 


### PR DESCRIPTION
We previously faced the same issue in LKRG and we fixed it by using `register_sysctl` unconditionally. We support kernels starting with RHEL7's 3.10'ish, so I guess this good enough for cryptodev-linux as well? This PR is mostly untested.

https://github.com/lkrg-org/lkrg/pull/282