### PR TITLE
Fixed a compiler optimisation bug in tests

### DIFF
--- a/lib/benchmark.c
+++ b/lib/benchmark.c
@@ -25,7 +25,7 @@
 #include <unistd.h>
 #include "benchmark.h"
 
-int benchmark_must_finish = 0;
+volatile int benchmark_must_finish = 0;
 
 static void
 alarm_handler (int signo)

--- a/lib/benchmark.h
+++ b/lib/benchmark.h
@@ -11,7 +11,7 @@ struct benchmark_st
   sighandler_t old_handler;
 };
 
-extern int benchmark_must_finish;
+extern volatile int benchmark_must_finish;
 
 int start_benchmark(struct benchmark_st * st);
 int stop_benchmark(struct benchmark_st * st, unsigned long * elapsed);

--- a/tests/fullspeed.c
+++ b/tests/fullspeed.c
@@ -37,7 +37,7 @@ static double udifftimeval(struct timeval start, struct timeval end)
 	       (double)(end.tv_sec - start.tv_sec) * 1000 * 1000;
 }
 
-static int must_finish = 0;
+static volatile int must_finish = 0;
 
 static void alarm_handler(int signo)
 {

--- a/tests/hashcrypt_speed.c
+++ b/tests/hashcrypt_speed.c
@@ -36,7 +36,7 @@ static double udifftimeval(struct timeval start, struct timeval end)
 	       (double)(end.tv_sec - start.tv_sec) * 1000 * 1000;
 }
 
-static int must_finish = 0;
+static volatile int must_finish = 0;
 
 static void alarm_handler(int signo)
 {

--- a/tests/sha_speed.c
+++ b/tests/sha_speed.c
@@ -35,7 +35,7 @@ static double udifftimeval(struct timeval start, struct timeval end)
 	       (double)(end.tv_sec - start.tv_sec) * 1000 * 1000;
 }
 
-static int must_finish = 0;
+static volatile int must_finish = 0;
 
 static void alarm_handler(int signo)
 {


### PR DESCRIPTION
added 'volatile' to sha_speed test's must_finish global variable since it otherwise may be optimized by the compiler in the following loop in hash_data:

    do {
        ...
    } while(must_finish==0);

Compiler: GCC 11.3
Target: 32bit ARM cortex-a9
Optimization: -O2