### PR TITLE
Fix: UAF in crypto_run + limit allocation size in adjust_sg_array

### DIFF
--- a/authenc.c
+++ b/authenc.c
@@ -54,7 +54,7 @@
 static int get_userbuf_tls(struct csession *ses, struct kernel_crypt_auth_op *kcaop,
 			struct scatterlist **dst_sg)
 {
-	int pagecount = 0;
+	unsigned int pagecount = 0;
 	struct crypt_auth_op *caop = &kcaop->caop;
 	int rc;
 
@@ -70,6 +70,12 @@ static int get_userbuf_tls(struct csession *ses, struct kernel_crypt_auth_op *kc
 	if (kcaop->dst_len == 0) {
 		dwarning(1, "Destination length cannot be zero");
 		return -EINVAL;
+	}
+
+	// we avoid overflows
+	if ((unsigned long) kcaop->dst_len > (unsigned long) (caop->dst + kcaop->dst_len)) {
+		dwarning(1, "Invalid destination or size");
+                return -EINVAL;
 	}
 
 	pagecount = PAGECOUNT(caop->dst, kcaop->dst_len);
@@ -105,8 +111,8 @@ static int get_userbuf_tls(struct csession *ses, struct kernel_crypt_auth_op *kc
 static int get_userbuf_srtp(struct csession *ses, struct kernel_crypt_auth_op *kcaop,
 			struct scatterlist **auth_sg, struct scatterlist **dst_sg)
 {
-	int pagecount, diff;
-	int auth_pagecount = 0;
+	unsigned int pagecount, diff;
+	unsigned int auth_pagecount = 0;
 	struct crypt_auth_op *caop = &kcaop->caop;
 	int rc;
 
@@ -128,6 +134,13 @@ static int get_userbuf_srtp(struct csession *ses, struct kernel_crypt_auth_op *k
 		dwarning(1, "Destination length cannot be zero");
 		return -EINVAL;
 	}
+
+	// we avoid overflows
+        if ((unsigned long) caop->auth_len > (unsigned long) (caop->auth_len + caop->auth_src)) {
+                dwarning(1, "Invalid destination or size");
+                return -EINVAL;
+        }
+
 
 	/* Note that in SRTP auth data overlap with data to be encrypted (dst)
          */

--- a/authenc.c
+++ b/authenc.c
@@ -213,7 +213,7 @@ static int cryptodev_get_dst_len(struct crypt_auth_op *caop, struct csession *se
 
 	/* for TLS always add some padding so the total length is rounded to
 	 * cipher block size */
-	if (caop->flags & COP_FLAG_AEAD_TLS_TYPE) {
+	if (caop->flags & COP_FLAG_AEAD_TLS_TYPE && ses_ptr->cdata.blocksize) {
 		int bs = ses_ptr->cdata.blocksize;
 		dst_len += bs - (dst_len % bs);
 	}

--- a/cryptlib.c
+++ b/cryptlib.c
@@ -473,6 +473,9 @@ int cryptodev_hash_copy(struct hash_data *dst, struct hash_data *src)
 	statesize = crypto_ahash_statesize(src->async.s);
 	if (unlikely(statesize <= 0)) {
 		return -EINVAL;
+	} else if (crypto_ahash_statesize(src->async.s) !=
+		   crypto_ahash_statesize(dst->async.s)) {
+		return -EINVAL;
 	}
 
 	statedata = kzalloc(statesize, GFP_KERNEL);

--- a/ioctl.c
+++ b/ioctl.c
@@ -922,6 +922,8 @@ cryptodev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg_)
 
 	if (unlikely(!pcr))
 		BUG();
+	if (unlikely(!arg_))
+		return -EINVAL;
 
 	fcr = &pcr->fcrypt;
 

--- a/ioctl.c
+++ b/ioctl.c
@@ -516,6 +516,11 @@ crypto_copy_hash_state(struct fcrypt *fcr, uint32_t dst_sid, uint32_t src_sid)
 		derr(1, "Failed to get sesssions with sid=0x%08X sid=%0x08X!",
 		     src_sid, dst_sid);
 		return ret;
+	} else if (crypto_ahash_statesize(dst_ses->hdata.async.s) != crypto_ahash_statesize(src_ses->hdata.async.s)) {
+		derr(1, "Mismatched state sizes between sessions 0x%08X and 0x%08X!",
+		     src_sid, dst_sid);
+		ret = -EINVAL;
+		return ret;
 	}
 
 	ret = cryptodev_hash_copy(&dst_ses->hdata, &src_ses->hdata);

--- a/ioctl.c
+++ b/ioctl.c
@@ -932,6 +932,9 @@ cryptodev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg_)
 
 	fcr = &pcr->fcrypt;
 
+	if (unlikely(!fcr))
+		return -EINVAL;
+
 	switch (cmd) {
 	case CIOCASYMFEAT:
 		return put_user(0, p);

--- a/ioctl.c
+++ b/ioctl.c
@@ -516,13 +516,8 @@ crypto_copy_hash_state(struct fcrypt *fcr, uint32_t dst_sid, uint32_t src_sid)
 		derr(1, "Failed to get sesssions with sid=0x%08X sid=%0x08X!",
 		     src_sid, dst_sid);
 		return ret;
-	} else if (crypto_ahash_statesize(dst_ses->hdata.async.s) != crypto_ahash_statesize(src_ses->hdata.async.s)) {
-		derr(1, "Mismatched state sizes between sessions 0x%08X and 0x%08X!",
-		     src_sid, dst_sid);
-		ret = -EINVAL;
-		return ret;
 	}
-
+	
 	ret = cryptodev_hash_copy(&dst_ses->hdata, &src_ses->hdata);
 	crypto_put_session(src_ses);
 	crypto_put_session(dst_ses);

--- a/main.c
+++ b/main.c
@@ -175,6 +175,15 @@ __crypto_run_zc(struct csession *ses_ptr, struct kernel_crypt_op *kcop)
 		return __crypto_run_std(ses_ptr, cop);
 	}
 
+	// if the src and dst are the same we need to clear the size otherwise
+	// the crypto api will iterate through the scatterlist causing a NULL
+	// pointer dereference and same issue if only one pointer is initialized
+	if (src_sg == dst_sg) {
+		cop->len = 0;
+	} else if ((src_sg && !dst_sg) || (!src_sg && dst_sg)) {
+		return 0;
+	}
+
 	ret = hash_n_crypt(ses_ptr, cop, src_sg, dst_sg, cop->len);
 
 	release_user_pages(ses_ptr);

--- a/main.c
+++ b/main.c
@@ -199,7 +199,10 @@ int crypto_run(struct fcrypt *fcr, struct kernel_crypt_op *kcop)
 	if (unlikely(cop->op != COP_ENCRYPT && cop->op != COP_DECRYPT)) {
 		ddebug(1, "invalid operation op=%u", cop->op);
 		return -EINVAL;
-	}
+	} else if (kcop->task != current || kcop->mm != current->mm) {
+		ddebug(1, "Yuo cannot call crypto_run from a different task/mm");
+		return -EINVAL;
+	} // avoid UAF by checking task and mm above
 
 	/* this also enters ses_ptr->sem */
 	ses_ptr = crypto_get_session_by_sid(fcr, cop->ses);

--- a/zc.c
+++ b/zc.c
@@ -118,6 +118,10 @@ int adjust_sg_array(struct csession *ses, int pagecount)
 	struct page **pages;
 	int array_size;
 
+	// patch: limit maximum pages to prevent excessive memory allocation
+	if (unlikely(pagecount > 1024))
+		return -ENOMEM;
+
 	for (array_size = ses->array_size; array_size < pagecount;
 	     array_size *= 2)
 		;


### PR DESCRIPTION
- I fixed a UAF in `crypto_run`, when `crypto_run` is called asynchronously the process which scheduled the task might get destroyed right after the async request, causing a UAF when `__get_userbuf` tries to access the target pages. To me there might be a security concern, an attacker might use the UAF to gain access to the address space of a privileged process allowing an arbitrary read / write primitive.
- I fixed a small bug in `adjust_sg_array` by restricting the allocation size to 2^10 pages.